### PR TITLE
Update american-chemical-society.csl. Adding title to article-journal citations.

### DIFF
--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -179,7 +179,10 @@
         </else-if>
         <else-if type="article-journal">
           <group delimiter=" ">
-            <text variable="container-title" font-style="italic" form="short"/>
+            <group delimiter=". ">
+              <text variable="title"/>
+              <text variable="container-title" font-style="italic" form="short"/>
+            </group>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
               <text variable="volume" font-style="italic"/>


### PR DESCRIPTION
A client noticed that the title was missing from journal references in ACS style. Based on my reading of the guide the title should be added as proposed.